### PR TITLE
Allow static port number in client config

### DIFF
--- a/LoopbackServer.py
+++ b/LoopbackServer.py
@@ -58,7 +58,7 @@ class LoopbackServer(http.server.ThreadingHTTPServer):
     ):
         if socket.has_ipv6:
             self.address_family = socket.AF_INET6
-        super().__init__(("localhost", 0), LoopbackHandler)
+        super().__init__(("localhost", urlsplit(client.redirect_uri).port or 0), LoopbackHandler)
         # configuration
         self.provider = provider
         self.client = client

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install requests jwcrypto
 
 ## Configuration
 
-Configuration of this script is simple. You can use any localhost address with a path component as redirect uri, for example http://localhost/redirect. When you register this app, your OpenID Provider will return client id and secret. Put these parameters into [code-flow.json](code-flow.json)
+Configuration of this script is simple. You can use any localhost address with a path component as redirect uri, for example http://localhost/redirect. When you register this app, your OpenID Provider will return client id and secret. Put these parameters into [code-flow.json](code-flow.json). If you specify a port number with the localhost address, the loopback redirect server will bind to that specific port, otherwise any available (random) port on that address will be used.
 
 Sample configuration request
 


### PR DESCRIPTION
Thanks for creating these two Python tools! I was experimenting with `code-flow.py` alongside Hashicorp Vault, and Vault (like perhaps other OIDC IDPs) requires a known, static list of redirect URIs in advance -- and the fact that one time, the Loopback server listens on `http://localhost:12345` and then another time it listens on `http://localhost:54321` wouldn't work.

So I figured I'd just create this patch where, if desired, a port number can be specified in the client config. Eg. if the client config contains

```json
  "redirect_uris": [
    "http://localhost/redirect"
  ],
```

then the loopback server will continue to listen on a random port number just as today, but if is eg.

```json
  "redirect_uris": [
    "http://localhost:12345/redirect"
  ],
```

then it will listen specifically on TCP port 12345.